### PR TITLE
Use 11.4.x branch of armadillo

### DIFF
--- a/configure
+++ b/configure
@@ -76,7 +76,7 @@ if [ -z ${ARMA_INCLUDE_PATH+x} ]; then
         echo ""
 
         mkdir ${WDIR}/arma_tmp
-        git clone --single-branch https://gitlab.com/conradsnicta/armadillo-code.git ${WDIR}/arma_tmp > /dev/null 2>&1
+        git clone --single-branch --branch "11.4.x" https://gitlab.com/conradsnicta/armadillo-code.git ${WDIR}/arma_tmp > /dev/null 2>&1
         mv ${WDIR}/arma_tmp/include/* ${WDIR}/include
         rm -rf ${WDIR}/arma_tmp
         ARMA_INCLUDE_PATH="./include"


### PR DESCRIPTION
This is to retain support for pre-c++14 compilers